### PR TITLE
[Refactor] Jwt 발급 방식 변경

### DIFF
--- a/src/main/java/com/kwcapstone/Kakao/Service/KaKaoProvider.java
+++ b/src/main/java/com/kwcapstone/Kakao/Service/KaKaoProvider.java
@@ -22,7 +22,7 @@ public class KaKaoProvider {
     @Value("${KAKAO_CLIENT_ID}")
     private String clientId;
 
-    @Value("${KAKAO_REDIRECT_URL}")
+    @Value("${KAKAO_REDIRECT_URI}")
     private String redirectUrl;
 
     @Value("${KAKAO_CLIENT_SECRET}")

--- a/src/main/java/com/kwcapstone/Repository/MemberRepository.java
+++ b/src/main/java/com/kwcapstone/Repository/MemberRepository.java
@@ -12,6 +12,7 @@ public interface MemberRepository extends MongoRepository<Member, ObjectId> {
     boolean existsByEmail(String email);
     Optional<Member> findByEmail(String email);
     Optional<Member> findByNameAndEmail(String name, String email);
+    Optional<Member> findByMemberId(ObjectId memberId);
 
-    Optional<Member> findBySocialId(String socialId);
+    //Optional<Member> findBySocialId(String socialId);
 }

--- a/src/main/java/com/kwcapstone/Security/JwtRequestFilter.java
+++ b/src/main/java/com/kwcapstone/Security/JwtRequestFilter.java
@@ -53,13 +53,13 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 
             //token이 유효한지, 만료되지 않았는지 checking
             if (jwtTokenProvider.isTokenValid(token)) {
-                //jwt에서 사용자 id를 추출
+                //jwt에서 String 한 ObjectId 추출
                 String memberId = jwtTokenProvider.getId(token);
 
                 //인증을 처리할 때 UserDetails 타입으로 사용자의 정보를 객체로 관리
                 //principalDetailService를 하는 이유는 따로 만들면 security랑 연동이 안된다고 함
                 UserDetails userDetails =
-                        principalDetailsService.loadUserByUsername(socialId);
+                        principalDetailsService.loadUserByUsername();
 
                 if (userDetails != null) {
                     //securityContext에 인증 정보 저장

--- a/src/main/java/com/kwcapstone/Security/JwtRequestFilter.java
+++ b/src/main/java/com/kwcapstone/Security/JwtRequestFilter.java
@@ -54,7 +54,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
             //token이 유효한지, 만료되지 않았는지 checking
             if (jwtTokenProvider.isTokenValid(token)) {
                 //jwt에서 사용자 id를 추출
-                String socialId = jwtTokenProvider.getId(token);
+                String memberId = jwtTokenProvider.getId(token);
 
                 //인증을 처리할 때 UserDetails 타입으로 사용자의 정보를 객체로 관리
                 //principalDetailService를 하는 이유는 따로 만들면 security랑 연동이 안된다고 함

--- a/src/main/java/com/kwcapstone/Security/JwtRequestFilter.java
+++ b/src/main/java/com/kwcapstone/Security/JwtRequestFilter.java
@@ -59,7 +59,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
                 //인증을 처리할 때 UserDetails 타입으로 사용자의 정보를 객체로 관리
                 //principalDetailService를 하는 이유는 따로 만들면 security랑 연동이 안된다고 함
                 UserDetails userDetails =
-                        principalDetailsService.loadUserByUsername();
+                        principalDetailsService.loadUserByUsername(memberId);
 
                 if (userDetails != null) {
                     //securityContext에 인증 정보 저장

--- a/src/main/java/com/kwcapstone/Security/PrincipalDetailsService.java
+++ b/src/main/java/com/kwcapstone/Security/PrincipalDetailsService.java
@@ -2,7 +2,9 @@ package com.kwcapstone.Security;
 
 import com.kwcapstone.Domain.Entity.Member;
 import com.kwcapstone.Repository.MemberRepository;
+import com.kwcapstone.Token.Service.TokenService;
 import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -17,11 +19,14 @@ import org.springframework.web.server.ResponseStatusException;
 @RequiredArgsConstructor
 public class PrincipalDetailsService implements UserDetailsService {
     private final MemberRepository memberRepository;
+    private final TokenService tokenService;
 
     //유저 이름으로
     @Override
-    public UserDetails loadUserByUsername(String socialId) throws UsernameNotFoundException {
-        Member member = memberRepository.findBySocialId(socialId)
+    public UserDetails loadUserByUsername(String stringMemberId) throws UsernameNotFoundException {
+        ObjectId memberId = tokenService.ConvertToObjectId(stringMemberId);
+
+        Member member = memberRepository.findByMemberId(memberId)
                 .orElseThrow(()-> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "존재하지 않는 사용자 입니다."));
 
         return new PrincipalDetails(member);

--- a/src/main/java/com/kwcapstone/Service/MemberService.java
+++ b/src/main/java/com/kwcapstone/Service/MemberService.java
@@ -213,8 +213,8 @@ public class MemberService {
     }
 
     private GoogleTokenResponseDto getGoogleToken(Member member) {
-        String newAccessToken = jwtTokenProvider.createAccessToken(member.getSocialId(), member.getRole().name());
-        String newRefreshToken = jwtTokenProvider.createRefreshToken(member.getSocialId(), member.getRole().name());
+        String newAccessToken = jwtTokenProvider.createAccessToken(member.getMemberId(), member.getRole().name());
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(member.getMemberId(), member.getRole().name());
 
         Optional<Token> present = tokenRepository.findByMemberId(member.getMemberId());
 
@@ -228,16 +228,9 @@ public class MemberService {
         return new GoogleTokenResponseDto(member.getMemberId(), newAccessToken);
     }
 
-    private String ConvertToStringType(ObjectId memberId){
-        return memberId.toHexString();
-    }
-
     private MemberLoginResponseDto getMemberToken(Member member) {
-        //memberId를 String 으로 받음
-        String stringMemberId = ConvertToStringType(member.getMemberId());
-
-        String newAccessToken = jwtTokenProvider.createGeneralAccessToken(stringMemberId, member.getRole().name());
-        String newRefreshToken = jwtTokenProvider.createGeneralRefreshToken(stringMemberId, member.getRole().name());
+        String newAccessToken = jwtTokenProvider.createAccessToken(member.getMemberId(), member.getRole().name());
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(member.getMemberId(), member.getRole().name());
 
         Optional<Token> present = tokenRepository.findByMemberId(member.getMemberId());
 

--- a/src/main/java/com/kwcapstone/Service/MemberService.java
+++ b/src/main/java/com/kwcapstone/Service/MemberService.java
@@ -20,6 +20,7 @@ import com.kwcapstone.Repository.MemberRepository;
 import com.kwcapstone.Token.Domain.Token;
 import com.kwcapstone.Token.JwtTokenProvider;
 import com.kwcapstone.Token.Repository.TokenRepository;
+import jakarta.servlet.Filter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
@@ -49,6 +50,7 @@ public class MemberService {
     private final EmailService emailService;
     private final GoogleOAuthService googleOAuthService;
     private final HttpSession httpSession;
+    private final Filter springSecurityFilterChain;
 
     // 회원가입
     @Transactional
@@ -226,9 +228,16 @@ public class MemberService {
         return new GoogleTokenResponseDto(member.getMemberId(), newAccessToken);
     }
 
+    private String ConvertToStringType(ObjectId memberId){
+        return memberId.toHexString();
+    }
+
     private MemberLoginResponseDto getMemberToken(Member member) {
-        String newAccessToken = jwtTokenProvider.createGeneralAccessToken(member.getRole().name());
-        String newRefreshToken = jwtTokenProvider.createGeneralRefreshToken(member.getRole().name());
+        //memberId를 String 으로 받음
+        String stringMemberId = ConvertToStringType(member.getMemberId());
+
+        String newAccessToken = jwtTokenProvider.createGeneralAccessToken(stringMemberId, member.getRole().name());
+        String newRefreshToken = jwtTokenProvider.createGeneralRefreshToken(stringMemberId, member.getRole().name());
 
         Optional<Token> present = tokenRepository.findByMemberId(member.getMemberId());
 

--- a/src/main/java/com/kwcapstone/Token/JwtTokenProvider.java
+++ b/src/main/java/com/kwcapstone/Token/JwtTokenProvider.java
@@ -4,6 +4,7 @@ import com.kwcapstone.Domain.Entity.MemberRole;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
+import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
@@ -72,8 +73,12 @@ public class JwtTokenProvider {
         return createGeneralToken(memberId, role, rTValidityMilliseconds);
     }
 
-    //소셜 로그인 jwt 발급
-    private String createToken(String socialId, String role, Long validityMilliseconds){
+    private String ConvertToStringType(ObjectId memberId){
+        return memberId.toHexString();
+    }
+
+    //소셜 로그인 & 일반 로그인 jwt 발급
+    private String createToken(ObjectId memberId, String role, Long validityMilliseconds){
         //Jwt에 사용자 정보를 저장하기 위해 필요한 것
         Claims claims = Jwts.claims();
         claims.put("memberId", socialId);

--- a/src/main/java/com/kwcapstone/Token/JwtTokenProvider.java
+++ b/src/main/java/com/kwcapstone/Token/JwtTokenProvider.java
@@ -54,6 +54,7 @@ public class JwtTokenProvider {
     }
 
     //Token 생성
+    //1. 소셜 로그인 발급
     public String createAccessToken(String socialId, String role){
         return createToken(socialId, role, aTValidityMilliseconds);
     }
@@ -62,12 +63,13 @@ public class JwtTokenProvider {
             return createToken(socialId, role,rTValidityMilliseconds);
     }
 
-    public String createGeneralAccessToken(String role) {
-        return createGeneralToken(role, aTValidityMilliseconds);
+    //2. 일반 로그인 발급
+    public String createGeneralAccessToken(String memberId, String role) {
+        return createGeneralToken(memberId, role, aTValidityMilliseconds);
     }
 
-    public String createGeneralRefreshToken(String role) {
-        return createGeneralToken(role, rTValidityMilliseconds);
+    public String createGeneralRefreshToken(String memberId, String role) {
+        return createGeneralToken(memberId, role, rTValidityMilliseconds);
     }
 
     //소셜 로그인 jwt 발급

--- a/src/main/java/com/kwcapstone/Token/JwtTokenProvider.java
+++ b/src/main/java/com/kwcapstone/Token/JwtTokenProvider.java
@@ -70,10 +70,11 @@ public class JwtTokenProvider {
         return createGeneralToken(role, rTValidityMilliseconds);
     }
 
+    //소셜 로그인 jwt 발급
     private String createToken(String socialId, String role, Long validityMilliseconds){
         //Jwt에 사용자 정보를 저장하기 위해 필요한 것
         Claims claims = Jwts.claims();
-        claims.put("socialId", socialId);
+        claims.put("memberId", socialId);
         claims.put("role", role);
 
         //현재시간 가져오기
@@ -90,8 +91,10 @@ public class JwtTokenProvider {
                 .compact(); //최종 Jwt 생성
     }
 
-    private String createGeneralToken(String role, Long validityMilliseconds) {
+    //일반 로그인 jwt 발급
+    private String createGeneralToken(String memberId, String role, Long validityMilliseconds) {
         Claims claims = Jwts.claims();
+        claims.put("memberId", memberId);
         claims.put("role", role);
 
         ZonedDateTime now = ZonedDateTime.now();
@@ -107,7 +110,7 @@ public class JwtTokenProvider {
 
     //Jwt 에서 사용자 Id 추출
     public String getId(String token) {
-        return getClaims(token).getBody().get("socialId", String.class);
+        return getClaims(token).getBody().get("memberId", String.class);
     }
 
     //Jwt 에서 role 추출

--- a/src/main/java/com/kwcapstone/Token/JwtTokenProvider.java
+++ b/src/main/java/com/kwcapstone/Token/JwtTokenProvider.java
@@ -56,22 +56,22 @@ public class JwtTokenProvider {
 
     //Token 생성
     //1. 소셜 로그인 발급
-    public String createAccessToken(String socialId, String role){
-        return createToken(socialId, role, aTValidityMilliseconds);
+    public String createAccessToken(ObjectId memberId, String role){
+        return createToken(memberId, role, aTValidityMilliseconds);
     }
 
-    public String createRefreshToken(String socialId, String role){
-            return createToken(socialId, role,rTValidityMilliseconds);
+    public String createRefreshToken(ObjectId memberId, String role){
+            return createToken(memberId, role,rTValidityMilliseconds);
     }
 
-    //2. 일반 로그인 발급
+    /*//2. 일반 로그인 발급
     public String createGeneralAccessToken(String memberId, String role) {
         return createGeneralToken(memberId, role, aTValidityMilliseconds);
     }
 
     public String createGeneralRefreshToken(String memberId, String role) {
         return createGeneralToken(memberId, role, rTValidityMilliseconds);
-    }
+    }*/
 
     private String ConvertToStringType(ObjectId memberId){
         return memberId.toHexString();
@@ -79,9 +79,10 @@ public class JwtTokenProvider {
 
     //소셜 로그인 & 일반 로그인 jwt 발급
     private String createToken(ObjectId memberId, String role, Long validityMilliseconds){
+        String stringMemberId = ConvertToStringType(memberId);
         //Jwt에 사용자 정보를 저장하기 위해 필요한 것
         Claims claims = Jwts.claims();
-        claims.put("memberId", socialId);
+        claims.put("memberId", stringMemberId);
         claims.put("role", role);
 
         //현재시간 가져오기
@@ -98,7 +99,7 @@ public class JwtTokenProvider {
                 .compact(); //최종 Jwt 생성
     }
 
-    //일반 로그인 jwt 발급
+    /* //일반 로그인 jwt 발급
     private String createGeneralToken(String memberId, String role, Long validityMilliseconds) {
         Claims claims = Jwts.claims();
         claims.put("memberId", memberId);
@@ -113,9 +114,9 @@ public class JwtTokenProvider {
                 .setExpiration(Date.from(tokenValidity.toInstant()))  // 만료 시간 설정
                 .signWith(secretKey, SignatureAlgorithm.HS256) // 서명 추가
                 .compact();  // 최종 JWT 생성
-    }
+    }*/
 
-    //Jwt 에서 사용자 Id 추출
+    //Jwt 에서 사용자 Id 추출(ObjecctId 타입인데 String 타입으로 추출)
     public String getId(String token) {
         return getClaims(token).getBody().get("memberId", String.class);
     }

--- a/src/main/java/com/kwcapstone/Token/Service/TokenService.java
+++ b/src/main/java/com/kwcapstone/Token/Service/TokenService.java
@@ -58,7 +58,7 @@ public class TokenService {
         return token.get();
     }
 
-    //socialId
+    //ObjectId
     private String validateRefreshToken(String refreshToken) {
         //토큰이 존재하는가?
         jwtTokenProvider.isTokenValid(refreshToken);

--- a/src/main/java/com/kwcapstone/Token/Service/TokenService.java
+++ b/src/main/java/com/kwcapstone/Token/Service/TokenService.java
@@ -25,7 +25,7 @@ public class TokenService {
     private final MemberRepository memberRepository;
 
     //String -> obejctId
-    private ObjectId ConvertToObjectId(String memberId){
+    public ObjectId ConvertToObjectId(String memberId){
         return new ObjectId(memberId);
     }
 

--- a/src/main/java/com/kwcapstone/Token/Service/TokenService.java
+++ b/src/main/java/com/kwcapstone/Token/Service/TokenService.java
@@ -8,6 +8,7 @@ import com.kwcapstone.Token.Domain.Convert.TokenConvert;
 import com.kwcapstone.Token.Repository.TokenRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +24,11 @@ public class TokenService {
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
 
+    //String -> obejctId
+    private ObjectId ConvertToObjectId(String memberId){
+        return new ObjectId(memberId);
+    }
+
     //refreshToken 업데이트
     public TokenResponse reissueToken(HttpServletRequest request) {
         //token 추출
@@ -30,14 +36,16 @@ public class TokenService {
         //refreshToken이랑 같은 Token 정보가 있는지 확인
         Token token = getToken(refreshToken);
 
-        //google이 String이라서
-        String socialId = validateRefreshToken(refreshToken);
+        //memberId
+        String stringMemberId = validateRefreshToken(refreshToken);
         String role = findRoleByRefrshToken(refreshToken);
 
+        ObjectId memberId = ConvertToObjectId(stringMemberId);
+
         String newAccessToken
-                = jwtTokenProvider.createAccessToken(socialId, role);
+                = jwtTokenProvider.createAccessToken(memberId, role);
         String newRefreshToken
-                = jwtTokenProvider.createRefreshToken(socialId, role);
+                = jwtTokenProvider.createRefreshToken(memberId, role);
 
         // refreshToken 업데이트
         token.changeToken(newAccessToken, newRefreshToken);
@@ -63,9 +71,9 @@ public class TokenService {
         //토큰이 존재하는가?
         jwtTokenProvider.isTokenValid(refreshToken);
 
-        String socialId = jwtTokenProvider.getId(refreshToken);
+        String memberId = jwtTokenProvider.getId(refreshToken);
 
-        return socialId;
+        return memberId;
     }
 
     //role

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,7 +12,7 @@ server.address=0.0.0.0
 #kakao
 kakao.key.client-id=${KAKAO_CLIENT_ID}
 kakao.key.client-secret=${KAKAO_CLIENT_SECRET}
-kakao.redirect-url=${KAKAO_REDIRECT_URL}
+kakao.redirect-url=${KAKAO_REDIRECT_URI}
 
 #google
 spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID}


### PR DESCRIPTION
## 작업 내용

> Jwt 발급에서 소셜 로그인과 일반 로그인 나누었던걸 합쳤음
> Jwt 발급에 원래 socialId 내용을 넣으려고 했으나 일반 로그인은 socialId 값이 없는 관계로 memberId로 변경함

## 참고 사항

> 현재 branch 이름이 erro-enum 이지만 jwt 발급 방식 변경의 내용을 다룬 branch 입니다...

## 연관 이슈

> Refactor #34 

<br>
