### PR TITLE
[Fix] 회의 종료 500에러

### DIFF
--- a/src/main/java/com/kwcapstone/Service/ConferenceService.java
+++ b/src/main/java/com/kwcapstone/Service/ConferenceService.java
@@ -136,21 +136,25 @@ public class ConferenceService {
         File file = new File(System.getProperty("java.io.tmpdir"), "script_" + projectIdStr + ".txt");
 
         if(!file.exists()) {
+            System.out.println("파일이 존재하지 않습니다: " + file.getAbsolutePath());
             return List.of();
         }
 
         ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(file, new TypeReference<List<SaveScriptDto>>() {});
-//        List<SaveScriptDto> scriptions = new ArrayList<>();
+        List<SaveScriptDto> scriptLists = new ArrayList<>();
 //
-//        try(BufferedReader br = new BufferedReader(new FileReader(file))) {
-//            String line;
-//            while((line = br.readLine()) != null) {
-//                SaveScriptDto saveScriptDto = mapper.readValue(line, SaveScriptDto.class);
-//                scriptions.add(saveScriptDto);
-//            }
-//        }
-//        return scriptions;
+//        String content = Files.readString(file.toPath(), StandardCharsets.UTF_8);
+//        System.out.println("파일 내용:\n" + content);
+
+        for(String line : Files.readAllLines(file.toPath(), StandardCharsets.UTF_8)) {
+            if(line.trim().isEmpty()) {
+                continue;
+            }
+            SaveScriptDto dto = mapper.readValue(line, SaveScriptDto.class);
+            scriptLists.add(dto);
+        }
+
+        return scriptLists;
     }
 
     public void saveProject(PrincipalDetails principalDetails, SaveProjectRequestDto requestDto) {

--- a/src/main/java/com/kwcapstone/Service/WebSocketService.java
+++ b/src/main/java/com/kwcapstone/Service/WebSocketService.java
@@ -119,11 +119,8 @@ public class WebSocketService {
                 //주요키워드
                 sendMainKeywords(1, projectIdStr, dto, null);
 
-                System.out.println("주요 키워드 ok ");
                 //요약본
                 sendSummary(projectIdStr, dto);
-
-                System.out.println("요약본 ok ");
 
                 // 임시 디렉토리 경로 확인 및 생성
                 String tmpDirPath = System.getProperty("java.io.tmpdir");
@@ -149,12 +146,9 @@ public class WebSocketService {
                 // 추천 키워드 전송
                 sendRecommendedKeywords(1, projectIdStr, null);
 
-                System.out.println("추천 키워드 ok ");
 
                 //노드 생성
                 createNode(projectIdStr,dto.getScription());
-
-                System.out.println("노드 키워드 ok ");
 
                 // 초기화
                 scriptBuffer.put(projectIdStr, new ArrayList<>());
@@ -363,7 +357,6 @@ public class WebSocketService {
                 throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "스크립트 저장 중 오류가 발생하였습니다." + e);
             }
         } else {
-            //노드 파일 만들기
             // 임시 디렉토리 경로 확인 및 생성
             String tmpDirPath = System.getProperty("java.io.tmpdir");
             File tmpDir = new File(tmpDirPath);
@@ -373,8 +366,9 @@ public class WebSocketService {
 
             // 임시 파일에 저장 (append 모드)
             String fileName = "script_" + projectId + ".txt";
-            File newFile = new File(System.getProperty("java.io.tmpdir"), fileName);
-            file = newFile;
+            File scriptNewFile;
+            scriptNewFile = new File(System.getProperty("java.io.tmpdir"), fileName);
+            file = scriptNewFile;
 
             content = scription;
         }
@@ -389,7 +383,6 @@ public class WebSocketService {
             //List<String> keywords = mapper.readValue(gptResult, new TypeReference<List<String>>() {});
             List<Map<String, Object>> gptNodes = mapper.readValue(gptResult, new TypeReference<List<Map<String, Object>>>() {
             });
-            System.out.println("GPT 결과: " + gptResult);
 
             List<NodeDto> currentNodes = sessionNodeBuffer.computeIfAbsent(projectId, k -> new ArrayList<>());
             List<NodeDto> newNodes = new ArrayList<>();
@@ -429,7 +422,6 @@ public class WebSocketService {
                     x = X_BASE;
                     y = i * Y_GAP;
                 }
-                System.out.println("positon은 문제 없는데,");
 
                 NodeDto node = NodeDto.builder()
                         .id(idMapping.get(originalId))
@@ -466,15 +458,16 @@ public class WebSocketService {
 
                 // 임시 파일에 저장 (append 모드)
                 String fileName = "node_" + projectId + ".txt";
-                File newFile = new File(System.getProperty("java.io.tmpdir"), fileName);
-                file = newFile;
+                File nodeNewFile;
+                nodeNewFile = new File(System.getProperty("java.io.tmpdir"), fileName);
+                nodeFile = nodeNewFile;
             }
 
             mapper = new ObjectMapper();
             String json = mapper.writeValueAsString(newNodes);
 
             //덮어씌우기
-            try (FileWriter writer = new FileWriter(file, false)) {
+            try (FileWriter writer = new FileWriter(nodeFile, false)) {
                 writer.write(json);
             }
             catch (IOException e) {


### PR DESCRIPTION
## 작업 내용

> 웹소켓 파일 저장 시, 노드 정보가 스크립트 파일에 중복 저장되고 있었음 -> 고침
> 파일 저장 내용이 배열 형태가 아닌 json 뭉텅이로 라인마다 저장되고 있었음 -> 이에 맞게 파일에 저장되도록 로직 수정

## 참고 사항

> 클라이언트 연동 이후 다시 들여다봐야할 것 같음

## 연관 이슈

> close #268

<br>
