### PR TITLE
[Fix] 알림 조회 버그 수정 

### DIFF
--- a/src/main/java/com/kwcapstone/Common/Response/BaseResponse.java
+++ b/src/main/java/com/kwcapstone/Common/Response/BaseResponse.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 public class BaseResponse<T> {
     private final int status;
     private final String message;
-    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonInclude(JsonInclude.Include.ALWAYS)
     private T data;
 
    /* public BaseResponse(int status, String message, T data) {
@@ -29,6 +29,7 @@ public class BaseResponse<T> {
     public BaseResponse(int status, String message) {
         this.status = status;
         this.message = message;
+        this.data = null;
     }
 
     //객체 지향을 위해서임

--- a/src/main/java/com/kwcapstone/Common/Response/SuccessStatus.java
+++ b/src/main/java/com/kwcapstone/Common/Response/SuccessStatus.java
@@ -42,10 +42,10 @@ public enum SuccessStatus implements BaseCode{
     USER_WITHDRAW(HttpStatus.OK, "회원 탈퇴가 완료되었습니다."),
 
     // 알림창 조회
-    NOTICE_CONFIRM(HttpStatus.OK, "모든 알림을 조회합니다."),
+    ALL_NOTICE_CONFIRM(HttpStatus.OK, "모든 알림을 조회합니다."),
 
-    // 알림창 세부 조회
-    NOTICE_DETAIL_CONFIRM(HttpStatus.OK, "알림 세부 조회입니다."),
+    // 알림창 unread 조회
+    UNREAD_NOTICE_CONFIRM(HttpStatus.OK, "읽지 않은 알림을 조회입니다."),
 
     // 메인화면 확인
     MAIN_SHOW(HttpStatus.OK, "모든 프로젝트 리스트를 불러왔습니다."),

--- a/src/main/java/com/kwcapstone/Controller/MainController.java
+++ b/src/main/java/com/kwcapstone/Controller/MainController.java
@@ -9,10 +9,10 @@ import com.kwcapstone.Service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.bson.types.ObjectId;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
 
 @RestController
 @RequiredArgsConstructor
@@ -25,7 +25,21 @@ public class MainController {
     @GetMapping("/notice")
     public BaseResponse noticeShow (@AuthenticationPrincipal PrincipalDetails principalDetails,
                                     @RequestParam(value = "type", defaultValue = "all") String type) {
-        return BaseResponse.res(SuccessStatus.NOTICE_CONFIRM, mainService.showNotice(principalDetails, type));
+
+        Object data = mainService.showNotice(principalDetails, type);
+
+        if(data == null){
+            if(type.equals("all")){
+                return BaseResponse.res(SuccessStatus.ALL_NOTICE_CONFIRM, null);
+            }else{
+                return BaseResponse.res(SuccessStatus.UNREAD_NOTICE_CONFIRM, null);
+            }
+        }
+        if(type.equals("all")){
+            return BaseResponse.res(SuccessStatus.ALL_NOTICE_CONFIRM, data);
+        }else{
+            return BaseResponse.res(SuccessStatus.UNREAD_NOTICE_CONFIRM, data);
+        }
     }
 
     // 알림창 세부 조회

--- a/src/main/java/com/kwcapstone/Service/MainService.java
+++ b/src/main/java/com/kwcapstone/Service/MainService.java
@@ -45,6 +45,7 @@ public class MainService {
     }
 
     // 알림창 전체 조회
+    @Transactional
     public List<NoticeReadResponseDto> showNotice(PrincipalDetails principalDetails, String type) {
         ObjectId objectId;
         ObjectId memberId = principalDetails.getId();
@@ -66,6 +67,9 @@ public class MainService {
             return null;
         }
 
+        //없데이트
+        markAsRead(notices);
+
         try {
             return notices.stream().map(notice -> {
                 String userName = memberRepository.findByMemberId(notice.getSenderId())
@@ -85,6 +89,16 @@ public class MainService {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
                     "알림 데이터를 불러오는 중 서버에서 예상치 못한 오류가 발생했습니다.");
         }
+    }
+
+    //알림 읽은 상태 조회 업데이트
+    private void markAsRead(List<Notice> notices){
+        List<Notice> unRead = notices.stream()
+                .filter(notice -> !notice.getIsRead()) //안 읽은 알림 조회
+                .peek(n-> n.setIsRead(true)) //필터링된 요소에 업데이트
+                .toList();
+
+        noticeRepository.saveAll(unRead);
     }
 
     private List<Project> getProjects(String memberId, String filterType) {


### PR DESCRIPTION
## 작업 내용

> 알림 조회 시, null 이어도 data가 나오도록 baseReasponse 수정 (include.Always로 null이어도 data 필드가 나오도록 수정)
>알림 상세조회 대신 알림 조회 시, 내부적으로 unRead가 read 되도록 상태 업데이트 함수 로직 추가 및 transactional 작업 로직 추가

## 참고 사항

> 없음

## 연관 이슈

> close #271 

<br>
