### PR TITLE
[Fix] 알림 읽음 상태 로직 순서 오류 고침

### DIFF
--- a/src/main/java/com/kwcapstone/Service/MainService.java
+++ b/src/main/java/com/kwcapstone/Service/MainService.java
@@ -67,24 +67,27 @@ public class MainService {
             return null;
         }
 
+        List<NoticeReadResponseDto> resultNotices
+                = notices.stream().map(notice -> {
+            String userName = memberRepository.findByMemberId(notice.getSenderId())
+                    .map(Member::getName)
+                    .orElse("Unknown");  // senderId에 해당하는 유저가 없을 경우
+
+            return new NoticeReadResponseDto(
+                    notice.getNoticeId(),
+                    userName,
+                    notice.getTitle(),
+                    notice.getUrl(),
+                    notice.getOfficial(),
+                    notice.getIsRead()
+            );
+        }).collect(Collectors.toList());
+
         //없데이트
         markAsRead(notices);
 
         try {
-            return notices.stream().map(notice -> {
-                String userName = memberRepository.findByMemberId(notice.getSenderId())
-                        .map(Member::getName)
-                        .orElse("Unknown");  // senderId에 해당하는 유저가 없을 경우
-
-                return new NoticeReadResponseDto(
-                        notice.getNoticeId(),
-                        userName,
-                        notice.getTitle(),
-                        notice.getUrl(),
-                        notice.getOfficial(),
-                        notice.getIsRead()
-                );
-            }).collect(Collectors.toList());
+            return resultNotices;
         } catch (Exception e) {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
                     "알림 데이터를 불러오는 중 서버에서 예상치 못한 오류가 발생했습니다.");


### PR DESCRIPTION
## 작업 내용

> 알림 읽음 상태에서 unRead가 true로 가는거 발견
-> 호출 이후로 true로 변동되도록 고침

## 참고 사항

> 없음

## 연관 이슈

> close #273 

<br>
