### PR TITLE
Fix: 메인화면 프로젝트 조회 수정

### DIFF
--- a/src/main/java/com/kwcapstone/Service/MainService.java
+++ b/src/main/java/com/kwcapstone/Service/MainService.java
@@ -168,7 +168,7 @@ public class MainService {
         List<Project> projects = getProjects(String.valueOf(memberId), filterType);
 
         if (projects.isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "요청한 조건에 맞는 프로젝트를 찾을 수 없습니다.");
+            return null;
         }
 
         try {
@@ -214,7 +214,7 @@ public class MainService {
         List<Project> projects = getProjects(String.valueOf(memberId), filterType);
 
         if (projects.isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "요청한 조건에 맞는 녹음 데이터를 찾을 수 없습니다.");
+            return null;
         }
 
         try {
@@ -274,7 +274,7 @@ public class MainService {
         List<Project> projects = getProjects(String.valueOf(memberId), filterType);
 
         if (projects.isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "요청한 조건에 맞는 요약본 데이터를 찾을 수 없습니다.");
+            return null;
         }
 
         try {


### PR DESCRIPTION
## 작업 내용
메인화면 프로젝트 조회 시 프로젝트가 존재하지 않을 때 404가 아닌 200 + null로 response가 오도록 수정했습니다.

## 참고 사항

## 연관 이슈
close #310 

<br>
